### PR TITLE
Migrate to .NET Core v2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: csharp
 sudo: required
-dotnet: 2.0.3
+dotnet: 2.1.300
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ pull_requests:
   do_not_increment_build_number: true
 environment:
   COVERALLS_REPO_TOKEN:
-    secure: yUQNhS1pNAjnGKbVNmWoncPTcR3zgaXXpal8pypY+OUs0hSSIkiDV+D1MwA7OK9T
+    secure: KG40pVjSM4eeoLiDWgy4Ckwla18mDysrHpXDLIBRyGE8/eVvQjMejIfHUK22pDNT
 branches:
   only:
   - master

--- a/src/Invio.Extensions.Core/Threading/Tasks/TaskExtensions.cs
+++ b/src/Invio.Extensions.Core/Threading/Tasks/TaskExtensions.cs
@@ -6,33 +6,36 @@ using System.Threading;
 using System.Threading.Tasks;
 
 namespace Invio.Extensions.Threading.Tasks {
+
     /// <summary>
-    /// Extension methods on the <see cref="Task" /> and <see cref="Task{T}" /> types.
+    ///   Extension methods on the <see cref="Task" /> and <see cref="Task{T}" /> types.
     /// </summary>
     public static class TaskExtensions {
+
         /// <summary>
-        /// Creates a new task that casts the result of the original task to a new type upon
-        /// completion.
+        ///   Creates a new task that casts the result of
+        ///   the original task to a new type upon completion.
         /// </summary>
         /// <remarks>
-        /// No type conversion is performed, so it is only possible to cast the result to the
-        /// actual type, a base type, or an implemented interface.
+        ///   No type conversion is performed, so it is only possible to cast the
+        ///   result to the actual type, a base type, or an implemented interface.
         /// </remarks>
         /// <see cref="Enumerable.Cast{T}"/>
         /// <param name="task">The input task.</param>
         /// <typeparam name="T">Th type to cast the result to.</typeparam>
         /// <returns>
-        /// A new task that casts theresult of the original task to the type
-        /// <typeparamref name="T" /> upon completion.
+        ///   A new task that casts theresult of the original task to the type
+        ///   <typeparamref name="T" /> upon completion.
         /// </returns>
         /// <exception cref="ArgumentNullException">
-        /// The parameter <paramref name="task" /> is null.
+        ///   The parameter <paramref name="task" /> is null.
         /// </exception>
         /// <exception cref="ArgumentException">
-        /// The parameter <paramref name="task" /> does not return a result.
+        ///   The parameter <paramref name="task" /> does not return a result.
         /// </exception>
         /// <exception cref="InvalidCastException">
-        /// The cast from the original task result type to <typeparamref name="T" /> is invalid.
+        ///   The cast from the original task result
+        ///   type to <typeparamref name="T" /> is invalid.
         /// </exception>
         public static Task<T> Cast<T>(this Task task) {
             if (task == null) {
@@ -44,7 +47,16 @@ namespace Invio.Extensions.Threading.Tasks {
             }
 
             var taskType = task.GetType();
-            if (!taskType.IsGenericType || taskType.GetGenericTypeDefinition() != typeof(Task<>)) {
+
+            do {
+                if (taskType.IsGenericType && taskType.GetGenericTypeDefinition() == typeof(Task<>)) {
+                    break;
+                }
+
+                taskType = taskType.BaseType;
+            } while (taskType != null);
+
+            if (taskType == null) {
                 throw new ArgumentException(
                     "Cannot cast Task with no result type.",
                     nameof(task)

--- a/test/Invio.Extensions.Core.Tests/Invio.Extensions.Core.Tests.csproj
+++ b/test/Invio.Extensions.Core.Tests/Invio.Extensions.Core.Tests.csproj
@@ -1,16 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <DebugType>portable</DebugType>
     <AssemblyName>Invio.Extensions.Core.Tests</AssemblyName>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <PackageId>Invio.Extensions.Core.Tests</PackageId>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <ProjectReference Include="..\..\src\Invio.Extensions.Core\Invio.Extensions.Core.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Invio.Extensions.Core\Invio.Extensions.Core.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I had to change the implementation of the `TaskExtensions.Cast<T>` extension method because the way that `Task` objects are managed in asynchronous code in v2.1. Now, there are objects that are child types of `Task<T>` that manage the state of `Task<T>`, not just `Task<T>` directly.

https://github.com/dotnet/corefx/issues/29977